### PR TITLE
Bugfix for Error Message Silent-Failure

### DIFF
--- a/src/static/script.js
+++ b/src/static/script.js
@@ -90,7 +90,7 @@ document
     if (verified) {
       printToStatus(statusRegister, getPassStatus());
     } else {
-      printToStatus(statusRegister, getFailureStatus(err));
+      printToStatus(statusRegister, getFailureStatus(msg));
     }
     printToDebug(
       dbgRegister,
@@ -149,7 +149,7 @@ document
     if (verified) {
       printToStatus(statusAuthenticate, getPassStatus());
     } else {
-      printToStatus(statusAuthenticate, getFailureStatus(err));
+      printToStatus(statusAuthenticate, getFailureStatus(msg));
     }
     printToDebug(
       dbgAuthenticate,


### PR DESCRIPTION
If you attempt to authenticate before registering, no error message is printed because the wrong variable is accessed. This patch fixes that bug.